### PR TITLE
Fixes #3: Add fields to publish metadata and build functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
    <version>1.5.0-SNAPSHOT</version>
   </dependency>
   <dependency>
-   <groupId>com.redhat.lightblue.mongo</groupId>
-   <artifactId>lightblue-mongo-metadata</artifactId>
+   <groupId>com.redhat.lightblue</groupId>
+   <artifactId>lightblue-core-metadata</artifactId>
    <version>1.5.0-SNAPSHOT</version>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
 
  <dependencies>
   <dependency>
+   <groupId>com.redhat.lightblue</groupId>
+   <artifactId>lightblue-core-config</artifactId>
+   <version>1.5.0-SNAPSHOT</version>
+  </dependency>
+  <dependency>
    <groupId>com.redhat.lightblue.mongo</groupId>
    <artifactId>lightblue-mongo-metadata</artifactId>
    <version>1.5.0-SNAPSHOT</version>
@@ -84,6 +89,13 @@
    <groupId>com.redhat.lightblue.mongo</groupId>
    <artifactId>lightblue-mongo-config</artifactId>
    <version>1.5.0-SNAPSHOT</version>
+   <scope>test</scope>
+  </dependency>
+  <dependency>
+   <groupId>org.skyscreamer</groupId>
+   <artifactId>jsonassert</artifactId>
+   <version>1.2.3</version>
+   <scope>test</scope>
   </dependency>
  </dependencies>
 

--- a/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
+++ b/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
@@ -70,6 +70,8 @@ public class PublishHook implements CRUDHook, LightblueFactoryAware {
 
             event.setCRUDOperation(doc.getCRUDOperation().toString());
 
+            event.setStatus("unprocessed");
+
             for (Field f : doc.getEntityMetadata().getEntitySchema().getIdentityFields()) {
                 Path p = f.getFullPath();
                 JsonNode node = null;

--- a/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
+++ b/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
@@ -1,23 +1,124 @@
 package com.redhat.lightblue.hook.publish;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Date;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.redhat.lightblue.DataError;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.config.LightblueFactory;
+import com.redhat.lightblue.config.LightblueFactoryAware;
+import com.redhat.lightblue.crud.InsertionRequest;
+import com.redhat.lightblue.hook.publish.model.Event;
+import com.redhat.lightblue.hook.publish.model.EventIdentity;
 import com.redhat.lightblue.hooks.CRUDHook;
 import com.redhat.lightblue.hooks.HookDoc;
 import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.Field;
 import com.redhat.lightblue.metadata.HookConfiguration;
+import com.redhat.lightblue.util.Error;
+import com.redhat.lightblue.util.Path;
 
-public class PublishHook implements CRUDHook {
+public class PublishHook implements CRUDHook, LightblueFactoryAware {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(PublishHook.class);
 
     public static final String HOOK_NAME = "publishHook";
+    public static final String ENTITY_NAME = "publish";
+    public static final String ERR_MISSING_ID = HOOK_NAME + ":MissingID";
 
+    private LightblueFactory lightblueFactory;
+
+    @Override
     public String getName() {
         return HOOK_NAME;
     }
 
-    public void processHook(EntityMetadata arg0, HookConfiguration arg1, List<HookDoc> arg2) {
-        // TODO Auto-generated method stub
+    @Override
+    public void setLightblueFactory(LightblueFactory factory) {
+        this.lightblueFactory = factory;
+    }
 
+    @Override
+    public void processHook(EntityMetadata entityMetadata, HookConfiguration hookConfiguration, List<HookDoc> docs) {
+        if (!(hookConfiguration instanceof PublishHookConfiguration)) {
+            throw new IllegalArgumentException("Only instances of PublishHookConfiguration are supported.");
+        }
+
+        PublishHookConfiguration publishHookConfiguration = (PublishHookConfiguration) hookConfiguration;
+
+        for (HookDoc doc : docs) {
+            Event event = new Event();
+
+            event.setEntityName(doc.getEntityMetadata().getName());
+            event.setVersionText(doc.getEntityMetadata().getVersion().getValue());
+
+            event.setCreatedBy(HOOK_NAME);
+            event.setCreationDate(new Date());
+
+            event.setLastUpdatedBy(HOOK_NAME);
+            event.setLastUpdateDate(new Date());
+
+            event.setCRUDOperation(doc.getCRUDOperation().toString());
+
+            for (Field f : doc.getEntityMetadata().getEntitySchema().getIdentityFields()) {
+                Path p = f.getFullPath();
+                JsonNode node = null;
+
+                if (doc.getPreDoc() != null) {
+                    node = doc.getPreDoc().get(p);
+                }
+                else if (doc.getPostDoc() != null) {
+                    node = doc.getPostDoc().get(p);
+                }
+                else {
+                    throw Error.get(ERR_MISSING_ID, "path:" + p.toString());
+                }
+
+                EventIdentity identity = new EventIdentity();
+                identity.setFieldText(p.toString());
+                identity.setValueText(node.asText());
+                event.addIdentities(identity);
+            }
+
+            try {
+                insert(ENTITY_NAME, event);
+            } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | NoSuchMethodException | InstantiationException | IOException e) {
+                //TODO Better Handle Exception
+                LOGGER.error("Unexpected error", e);
+            }
+        }
+    }
+
+    private void insert(String entityName, Object entity) throws ClassNotFoundException, IllegalAccessException, InvocationTargetException, IOException, NoSuchMethodException, InstantiationException {
+        ObjectNode jsonNode = new ObjectNode(JsonNodeFactory.instance);
+        jsonNode.put("entity", entityName);
+        ArrayNode data = jsonNode.putArray("data");
+        data.add(new ObjectMapper().valueToTree(entity));
+
+        InsertionRequest ireq = InsertionRequest.fromJson(jsonNode);
+        Response r = lightblueFactory.getMediator().insert(ireq);
+        if (!r.getErrors().isEmpty()) {
+            //TODO Better Handle Exception
+            for (Error e : r.getErrors()) {
+                LOGGER.error(e.toString());
+            }
+        }
+        else if (!r.getDataErrors().isEmpty()) {
+            //TODO Better Handle Exception
+            for (DataError e : r.getDataErrors()) {
+                LOGGER.error(e.toString());
+            }
+        }
     }
 
 }

--- a/src/main/java/com/redhat/lightblue/hook/publish/PublishHookConfigurationParser.java
+++ b/src/main/java/com/redhat/lightblue/hook/publish/PublishHookConfigurationParser.java
@@ -7,22 +7,25 @@ import com.redhat.lightblue.metadata.parser.MetadataParser;
 
 public class PublishHookConfigurationParser<T> implements HookConfigurationParser<T> {
 
+    @Override
     public String getName() {
         return PublishHook.HOOK_NAME;
     }
 
+    @Override
     public CRUDHook getCRUDHook() {
         return new PublishHook();
     }
 
+    @Override
     public void convert(MetadataParser<T> parser, T emptyNode, HookConfiguration object) {
         // TODO Auto-generated method stub
 
     }
 
+    @Override
     public HookConfiguration parse(String name, MetadataParser<T> parser, T node) {
-        // TODO Auto-generated method stub
-        return null;
+        return new PublishHookConfiguration();
     }
 
 }

--- a/src/main/java/com/redhat/lightblue/hook/publish/model/Event.java
+++ b/src/main/java/com/redhat/lightblue/hook/publish/model/Event.java
@@ -1,0 +1,96 @@
+package com.redhat.lightblue.hook.publish.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.lightblue.metadata.types.DateType;
+
+public class Event {
+
+    private String entityName;
+    private String versionText;
+    private String createdBy;
+    private Date creationDate;
+    private Date lastUpdateDate;
+    private String lastUpdatedBy;
+    private String CRUDOperation;
+    private final List<EventIdentity> identity = new ArrayList<>();
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public void setEntityName(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public String getVersionText() {
+        return versionText;
+    }
+
+    public void setVersionText(String versionText) {
+        this.versionText = versionText;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    @JsonFormat(pattern = DateType.DATE_FORMAT_STR)
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    @JsonFormat(pattern = DateType.DATE_FORMAT_STR)
+    public Date getLastUpdateDate() {
+        return lastUpdateDate;
+    }
+
+    public void setLastUpdateDate(Date lastUpdateDate) {
+        this.lastUpdateDate = lastUpdateDate;
+    }
+
+    public String getLastUpdatedBy() {
+        return lastUpdatedBy;
+    }
+
+    public void setLastUpdatedBy(String lastUpdatedBy) {
+        this.lastUpdatedBy = lastUpdatedBy;
+    }
+
+    @JsonProperty("CRUDOperation")
+    public String getCRUDOperation() {
+        return CRUDOperation;
+    }
+
+    public void setCRUDOperation(String CRUDOperation) {
+        this.CRUDOperation = CRUDOperation;
+    }
+
+    public List<EventIdentity> getIdentity() {
+        return identity;
+    }
+
+    public void addIdentities(Collection<EventIdentity> eventIdentities) {
+        identity.addAll(eventIdentities);
+    }
+
+    public void addIdentities(EventIdentity... eventIdentities) {
+        for (EventIdentity id : eventIdentities) {
+            identity.add(id);
+        }
+    }
+
+}

--- a/src/main/java/com/redhat/lightblue/hook/publish/model/Event.java
+++ b/src/main/java/com/redhat/lightblue/hook/publish/model/Event.java
@@ -19,6 +19,8 @@ public class Event {
     private String lastUpdatedBy;
     private String CRUDOperation;
     private final List<EventIdentity> identity = new ArrayList<>();
+    private String status;
+    private String notes;
 
     public String getEntityName() {
         return entityName;
@@ -91,6 +93,22 @@ public class Event {
         for (EventIdentity id : eventIdentities) {
             identity.add(id);
         }
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
     }
 
 }

--- a/src/main/java/com/redhat/lightblue/hook/publish/model/EventIdentity.java
+++ b/src/main/java/com/redhat/lightblue/hook/publish/model/EventIdentity.java
@@ -1,0 +1,24 @@
+package com.redhat.lightblue.hook.publish.model;
+
+public class EventIdentity {
+
+    private String fieldText;
+    private String valueText;
+
+    public String getFieldText() {
+        return fieldText;
+    }
+
+    public void setFieldText(String fieldText) {
+        this.fieldText = fieldText;
+    }
+
+    public String getValueText() {
+        return valueText;
+    }
+
+    public void setValueText(String valueText) {
+        this.valueText = valueText;
+    }
+
+}

--- a/src/main/resources/metadata/publish.json
+++ b/src/main/resources/metadata/publish.json
@@ -18,6 +18,18 @@
                     "FIND"
                 ]
             }
+        ],
+        "indexes": [
+            {
+                "fields": [
+                    {
+                        "field": "status",
+                        "dir": "$asc"
+                    }
+                ],
+                "name": "status index",
+                "unique": false
+            }
         ]
     },
     "schema": {
@@ -67,7 +79,7 @@
                 "type": "string",
                 "description": "Who created the event.",
                 "constraints": {
-                    "identity": true
+                    "required": true
                 }
             },
             "lastUpdateDate": {
@@ -81,14 +93,14 @@
                 "type": "string",
                 "description": "Who last changed the event.",
                 "constraints": {
-                    "identity": true
+                    "required": true
                 }
             },
             "CRUDOperation": {
                 "type": "string",
                 "description": "The operation executed when the event occurred.",
                 "constraints": {
-                    "identity": true,
+                    "required": true,
                     "enum": "CRUDOperationTypes"
                 }
             },
@@ -113,6 +125,20 @@
                             }
                         }
                     }
+                }
+            },
+            "status": {
+                "type": "string",
+                "description": "Indicates the process state of this event.",
+                "constraints": {
+                    "required": true
+                }
+            },
+            "notes": {
+                "type": "string",
+                "description": "Optional field for Operators to provide notes.",
+                "constraints": {
+                    "required": false
                 }
             }
         }

--- a/src/main/resources/metadata/publish.json
+++ b/src/main/resources/metadata/publish.json
@@ -6,7 +6,19 @@
             "backend": "mongo",
             "datasource": "mongodata",
             "collection": "publish"
-        }
+        },
+        "enums": [
+            {
+                "name": "CRUDOperationTypes",
+                "values": [
+                    "INSERT", 
+                    "SAVE", 
+                    "UPDATE", 
+                    "DELETE", 
+                    "FIND"
+                ]
+            }
+        ]
     },
     "schema": {
         "name": "publish",
@@ -28,6 +40,79 @@
                 "type": "uid",
                 "constraints": {
                     "identity": true
+                }
+            },
+            "entityName": {
+                "type": "string",
+                "description": "Name of the entity that generated the event",
+                "constraints": {
+                    "required": true
+                }
+            },
+            "versionText": {
+                "type": "string",
+                "description": "Version of entity that generated the event",
+                "constraints": {
+                    "required": true
+                }
+            },
+            "creationDate": {
+                "type": "date",
+                "description": "When the event was generated.",
+                "constraints": {
+                    "required": true
+                }
+            },
+            "createdBy": {
+                "type": "string",
+                "description": "Who created the event.",
+                "constraints": {
+                    "identity": true
+                }
+            },
+            "lastUpdateDate": {
+                "type": "date",
+                "description": "When the event was last changed.",
+                "constraints": {
+                    "required": true
+                }
+            },
+            "lastUpdatedBy": {
+                "type": "string",
+                "description": "Who last changed the event.",
+                "constraints": {
+                    "identity": true
+                }
+            },
+            "CRUDOperation": {
+                "type": "string",
+                "description": "The operation executed when the event occurred.",
+                "constraints": {
+                    "identity": true,
+                    "enum": "CRUDOperationTypes"
+                }
+            },
+            "identity": {
+                "type": "array",
+                "description": "The fields that identify the document the event happened on",
+                "items": {
+                    "type": "object",
+                    "fields": {
+                        "fieldText": {
+                            "type": "string",
+                            "description": "The path for this identity field.",
+                            "constraints": {
+                                "required": true
+                            }
+                        },
+                        "valueText": {
+                            "type": "string",
+                            "description": "The value for this identity field.",
+                            "constraints": {
+                                "required": true
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/test/java/com/redhat/lightblue/hook/publish/ITPublishHookTest.java
+++ b/src/test/java/com/redhat/lightblue/hook/publish/ITPublishHookTest.java
@@ -10,6 +10,7 @@ import java.net.UnknownHostException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.lightblue.Response;
@@ -48,7 +49,7 @@ public class ITPublishHookTest extends AbstractMongoCRUDTestController {
      * If no trigger is provided, then all actions of the CRUD type will create events.
      */
     @Test
-    public void testPublishWithDefaultTrigger() throws Exception {
+    public void testPublish() throws Exception {
         Response insertResponse = getLightblueFactory().getMediator().insert(createRequest_FromJsonString(
                 InsertionRequest.class,
                 "{\"entity\":\"country\",\"entityVersion\":\"" + COUNTRY_VERSION + "\",\"data\":["
@@ -66,6 +67,10 @@ public class ITPublishHookTest extends AbstractMongoCRUDTestController {
         assertNoErrors(findResponse);
         assertNoDataErrors(findResponse);
         assertEquals(1, findResponse.getMatchCount());
-    }
 
+        //dates and uids had to be left out to prevent test from always failing.
+        JSONAssert.assertEquals("[{\"identity\":[{\"fieldText\":\"_id\"},{\"valueText\":\"123\",\"fieldText\":\"iso2Code\"},{\"valueText\":\"456\",\"fieldText\":\"iso3Code\"}],\"createdBy\":\"publishHook\",\"versionText\":\"0.1.0-SNAPSHOT\",\"status\":\"unprocessed\",\"lastUpdatedBy\":\"publishHook\",\"notes\":null,\"CRUDOperation\":\"INSERT\",\"entityName\":\"country\",\"objectType\":\"publish\",\"identity#\":3}]",
+                findResponse.getEntityData().toString(),
+                false);
+    }
 }

--- a/src/test/java/com/redhat/lightblue/hook/publish/ITPublishHookTest.java
+++ b/src/test/java/com/redhat/lightblue/hook/publish/ITPublishHookTest.java
@@ -1,15 +1,26 @@
 package com.redhat.lightblue.hook.publish;
 
+import static com.redhat.lightblue.test.Assert.assertNoDataErrors;
+import static com.redhat.lightblue.test.Assert.assertNoErrors;
 import static com.redhat.lightblue.util.JsonUtils.json;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
+import java.net.UnknownHostException;
+
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.crud.FindRequest;
+import com.redhat.lightblue.crud.InsertionRequest;
 import com.redhat.lightblue.mongo.test.AbstractMongoCRUDTestController;
 
 public class ITPublishHookTest extends AbstractMongoCRUDTestController {
+
+    private static final String PUBLISH_VERSION = "0.0.1-SNAPSHOT";
+    private static final String COUNTRY_VERSION = "0.1.0-SNAPSHOT";
 
     @BeforeClass
     public static void preparePublishHookDatasources() {
@@ -23,14 +34,38 @@ public class ITPublishHookTest extends AbstractMongoCRUDTestController {
     @Override
     protected JsonNode[] getMetadataJsonNodes() throws Exception {
         return new JsonNode[]{
-                json(loadResource("/metadata/publish.json", true))
+                json(loadResource("/metadata/publish.json", true)),
+                json(loadResource("/metadata/country_with_publishhook.json", true))
         };
     }
 
+    @Before
+    public void before() throws UnknownHostException {
+        cleanupMongoCollections("country", "publish");
+    }
+
+    /**
+     * If no trigger is provided, then all actions of the CRUD type will create events.
+     */
     @Test
-    public void test() {
-        assertTrue(true);
-        //TODO Something meaningful.
+    public void testPublishWithDefaultTrigger() throws Exception {
+        Response insertResponse = getLightblueFactory().getMediator().insert(createRequest_FromJsonString(
+                InsertionRequest.class,
+                "{\"entity\":\"country\",\"entityVersion\":\"" + COUNTRY_VERSION + "\",\"data\":["
+                        + "{\"name\":\"United States\",\"iso2Code\":\"123\",\"iso3Code\":\"456\"}"
+                        + "]}"));
+        assertNoErrors(insertResponse);
+        assertNoDataErrors(insertResponse);
+        assertEquals(1, insertResponse.getModifiedCount());
+
+        Response findResponse = getLightblueFactory().getMediator().find(createRequest_FromJsonString(
+                FindRequest.class,
+                "{\"entity\":\"publish\",\"entityVersion\":\"" + PUBLISH_VERSION + "\","
+                        + "\"query\":{\"field\":\"objectType\",\"op\":\"$eq\",\"rvalue\":\"publish\"},"
+                        + "\"projection\": [{\"field\":\"*\",\"include\":true,\"recursive\":true}]}"));
+        assertNoErrors(findResponse);
+        assertNoDataErrors(findResponse);
+        assertEquals(1, findResponse.getMatchCount());
     }
 
 }

--- a/src/test/resources/metadata/country_with_publishhook.json
+++ b/src/test/resources/metadata/country_with_publishhook.json
@@ -1,0 +1,82 @@
+{
+    "entityInfo": {
+        "name": "country",
+        "hooks": [
+            {
+                "name": "publishHook",
+                "configuration": {
+                    
+                },
+                "actions": [
+                    "insert",
+                    "update",
+                    "delete"
+                ]
+            }
+        ],
+        "indexes": [
+            {
+                "unique": true,
+                "fields": [
+                    {
+                        "field": "iso2Code",
+                        "dir": "$asc"
+                    }
+                ]
+            },
+            {
+                "unique": true,
+                "fields": [
+                    {
+                        "field": "iso3Code",
+                        "dir": "$asc"
+                    }
+                ]
+            }
+        ],
+        "datastore": {
+            "backend": "mongo",
+            "datasource": "mongodata",
+            "collection": "country"
+        }
+    },
+    "schema": {
+        "name": "country",
+        "version": {
+            "value": "0.1.0-SNAPSHOT",
+            "changelog": "Initial version"
+        },
+        "status": {
+            "value": "active"
+        },
+        "access": {
+            "insert": ["anyone"],
+            "find": ["anyone"],
+            "update": ["anyone"],
+            "delete": ["anyone"]
+        },
+        "fields": {
+            "name": {
+                "type": "string",
+                "constraints": {
+                    "required": true
+                }
+            },
+            "iso2Code": {
+                "type": "string",
+                "constraints": {
+                    "identity": true
+                }
+            },
+            "iso3Code": {
+                "type": "string",
+                "constraints": {
+                    "identity": true
+                }
+            },
+            "optionalField": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/src/test/resources/mongo-lightblue-metadata.json
+++ b/src/test/resources/mongo-lightblue-metadata.json
@@ -1,0 +1,8 @@
+{
+    "type" : "com.redhat.lightblue.mongo.config.MongoMetadataConfiguration",
+    "dataSource" : "${mongo.datasource}",
+    "collection": "metadata",
+    "hookConfigurationParsers": [
+        "com.redhat.lightblue.hook.publish.PublishHookConfigurationParser"
+    ]
+}


### PR DESCRIPTION
- This creates  most of the fields mentioned in https://github.com/lightblue-platform/lightblue-publish-hook/issues/3 with the notable exception status which still has some ongoing discussion.
- Adds in the functionality to insert the entity into mongo
