### PR TITLE
An unknown who should not block the event

### DIFF
--- a/publish-hook/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
+++ b/publish-hook/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONCompare;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -86,7 +87,7 @@ public class PublishHook implements CRUDHook, LightblueFactoryAware {
                             LOGGER.debug("integrationProjectedPostDoc: {}", integrationProjectedPostDoc);
                             LOGGER.debug("identityProjectedPostDoc: {}", identityProjectedPostDoc);
                             Set<Event> extractedEvents = EventExctractionUtil.compareAndExtractEvents(
-                                    integrationProjectedPreDoc, 
+                                    integrationProjectedPreDoc,
                                     integrationProjectedPostDoc,
                                     identityProjectedPostDoc);
                             for (Event event : extractedEvents) {
@@ -102,7 +103,13 @@ public class PublishHook implements CRUDHook, LightblueFactoryAware {
                                 event.setLastUpdatedBy(HOOK_NAME);
                                 event.setLastUpdateDate(doc.getWhen());
                                 event.setStatus(Event.Status.UNPROCESSED);
-                                event.setEventSource(doc.getWho());
+
+                                if (StringUtils.isEmpty(doc.getWho())) {
+                                    event.setEventSource(doc.getWho());
+                                } else {
+                                    event.setEventSource("Unknown");
+                                }
+
                                 if (eventConfiguration.getRootIdentityFields() != null && eventConfiguration.getRootIdentityFields().size() > 0) {
                                     event.addRootIdentities(getRootIdentities(event.getIdentity(), eventConfiguration.getRootIdentityFields()));
                                 }

--- a/publish-hook/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
+++ b/publish-hook/src/main/java/com/redhat/lightblue/hook/publish/PublishHook.java
@@ -104,7 +104,7 @@ public class PublishHook implements CRUDHook, LightblueFactoryAware {
                                 event.setLastUpdateDate(doc.getWhen());
                                 event.setStatus(Event.Status.UNPROCESSED);
 
-                                if (StringUtils.isEmpty(doc.getWho())) {
+                                if (!StringUtils.isEmpty(doc.getWho())) {
                                     event.setEventSource(doc.getWho());
                                 } else {
                                     event.setEventSource("Unknown");


### PR DESCRIPTION
I am requesting this change because for some unit testing downstream projects, certs are not used. So no principal exists.

In the real world, non-cert deployments will have a null who. This would prevent the hook from breaking in that case.
